### PR TITLE
Exclure des jours lors de la création d'un créneau campagne

### DIFF
--- a/back/api/application/documentation/1.0.0/application.json
+++ b/back/api/application/documentation/1.0.0/application.json
@@ -751,6 +751,9 @@
               "scene_grid": {
                 "type": "boolean"
               },
+              "exclude_days": {
+                "type": "object"
+              },
               "published_at": {
                 "type": "string"
               },

--- a/back/api/booking/documentation/1.0.0/booking.json
+++ b/back/api/booking/documentation/1.0.0/booking.json
@@ -750,6 +750,9 @@
                 "scene_grid": {
                   "type": "boolean"
                 },
+                "exclude_days": {
+                  "type": "object"
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/back/api/campaign/documentation/1.0.0/campaign.json
+++ b/back/api/campaign/documentation/1.0.0/campaign.json
@@ -637,6 +637,9 @@
                 "scene_grid": {
                   "type": "boolean"
                 },
+                "exclude_days": {
+                  "type": "object"
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/back/api/disponibility/documentation/1.0.0/disponibility.json
+++ b/back/api/disponibility/documentation/1.0.0/disponibility.json
@@ -1050,6 +1050,9 @@
           "scene_grid": {
             "type": "boolean"
           },
+          "exclude_days": {
+            "type": "object"
+          },
           "published_at": {
             "type": "string",
             "format": "date-time"
@@ -1129,6 +1132,9 @@
           },
           "scene_grid": {
             "type": "boolean"
+          },
+          "exclude_days": {
+            "type": "object"
           },
           "published_at": {
             "type": "string",

--- a/back/api/disponibility/models/disponibility.settings.json
+++ b/back/api/disponibility/models/disponibility.settings.json
@@ -82,6 +82,9 @@
     },
     "scene_grid": {
       "type": "boolean"
+    },
+    "exclude_days": {
+      "type": "json"
     }
   }
 }

--- a/back/api/dispositif/documentation/1.0.0/dispositif.json
+++ b/back/api/dispositif/documentation/1.0.0/dispositif.json
@@ -603,6 +603,9 @@
                 "scene_grid": {
                   "type": "boolean"
                 },
+                "exclude_days": {
+                  "type": "object"
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/back/api/espace/documentation/1.0.0/espace.json
+++ b/back/api/espace/documentation/1.0.0/espace.json
@@ -1011,6 +1011,9 @@
                 "scene_grid": {
                   "type": "boolean"
                 },
+                "exclude_days": {
+                  "type": "object"
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/back/api/message/documentation/1.0.0/message.json
+++ b/back/api/message/documentation/1.0.0/message.json
@@ -1244,6 +1244,9 @@
                 "scene_grid": {
                   "type": "boolean"
                 },
+                "exclude_days": {
+                  "type": "object"
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/back/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/back/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "02/13/2024 5:12:15 PM"
+    "x-generation-date": "02/13/2024 5:27:13 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -10829,6 +10829,9 @@
               "scene_grid": {
                 "type": "boolean"
               },
+              "exclude_days": {
+                "type": "object"
+              },
               "published_at": {
                 "type": "string"
               },
@@ -11079,6 +11082,9 @@
                 },
                 "scene_grid": {
                   "type": "boolean"
+                },
+                "exclude_days": {
+                  "type": "object"
                 },
                 "published_at": {
                   "type": "string"
@@ -12073,6 +12079,9 @@
           "scene_grid": {
             "type": "boolean"
           },
+          "exclude_days": {
+            "type": "object"
+          },
           "published_at": {
             "type": "string",
             "format": "date-time"
@@ -12152,6 +12161,9 @@
           },
           "scene_grid": {
             "type": "boolean"
+          },
+          "exclude_days": {
+            "type": "object"
           },
           "published_at": {
             "type": "string",
@@ -12253,6 +12265,9 @@
                 },
                 "scene_grid": {
                   "type": "boolean"
+                },
+                "exclude_days": {
+                  "type": "object"
                 },
                 "published_at": {
                   "type": "string"

--- a/web/@types/schedule-event.d.ts
+++ b/web/@types/schedule-event.d.ts
@@ -20,5 +20,6 @@ export interface ScheduleEvent {
     hasEventSameDay?: boolean
     type: ScheduleEventType
     isCampaignEvent?: boolean
+    exclude_days?: string[]
   }
 }

--- a/web/components/Account/Place/ListItem/SubInfo.tsx
+++ b/web/components/Account/Place/ListItem/SubInfo.tsx
@@ -24,8 +24,6 @@ const SubInfo = ({ place, available, isMobile = false, isComplete = true }) => {
   const { t } = useTranslation('place')
   const { coming, past, pending } = useNbBooking(place.disponibilities)
 
-  console.log(place?.filledUntil)
-
   return (
     <Stack
       direction={{ base: 'column', lg: 'row' }}

--- a/web/components/Account/Place/PlaceTabList.tsx
+++ b/web/components/Account/Place/PlaceTabList.tsx
@@ -47,7 +47,7 @@ const PlaceTabList = ({
       (dispo) =>
         dispo.status === DisponibilityStatus.AVAILABLE && !dispo.campaign,
     ).length
-  }, [place])
+  }, [place.disponibilities])
 
   const campaignDispo = useMemo(() => {
     if (!place || !place.disponibilities) return 0

--- a/web/components/Account/Place/Schedule.tsx
+++ b/web/components/Account/Place/Schedule.tsx
@@ -10,6 +10,26 @@ import { useFormContext } from 'react-hook-form'
 import isSameDay from 'date-fns/isSameDay'
 import isToday from 'date-fns/isToday'
 import useCampaignContext from '~components/Campaign/useCampaignContext'
+import { format } from '~utils/date'
+import styled from '@emotion/styled'
+
+export const StyleWrapper = styled.div`
+  ${(props) => props.className} {
+    background: repeating-linear-gradient(
+      -45deg,
+      white,
+      white 5px,
+      #ebecf2 5px,
+      #ebecf2 10px
+    );
+    inset: 0;
+    display: block;
+    position: absolute;
+    z-index: 20;
+    border-radius: 8px;
+    margin: 3px 2px 3px 2px;
+  }
+`
 
 const Schedule = ({ isCampaignMode }: { isCampaignMode?: boolean }) => {
   const { currentCampaign } = useCampaignContext()
@@ -76,6 +96,40 @@ const Schedule = ({ isCampaignMode }: { isCampaignMode?: boolean }) => {
       })
   }, [oldEvents, newEvents])
 
+  // useEffect(() => {
+  // const events = [...oldEvents, ...newEvents]
+
+  // events.forEach((event) => {
+  //   const dates = event?.extendedProps?.exclude_days?.map((el) =>
+  //     format(el, 'yyyy-MM-dd'),
+  //   )
+
+  //   dates?.map((date) => {
+  //     const elements = document.querySelectorAll(`[data-date="${date}"]`)
+  //     elements.forEach((element) => {
+  //       element.classList.add('my-custom-class')
+  //     })
+  //   })
+  // })
+  // }, [oldEvents, newEvents])
+
+  const excludedDaysClassName = useMemo(() => {
+    // td[data-date=“2024-02-16"]::after
+    let classNames = []
+    const events = [...oldEvents, ...newEvents]
+
+    events.forEach((event) => {
+      const dates = event?.extendedProps?.exclude_days?.map((el) =>
+        format(el, 'yyyy-MM-dd'),
+      )
+
+      dates?.map((date) => {
+        classNames.push(`[data-date='${date}'] .fc-daygrid-day-frame:after`)
+      })
+    })
+    return classNames.join(', ')
+  }, [oldEvents, newEvents])
+
   return (
     <Flex
       w={{ base: 'calc(100% + 1.5rem)', md: '100%', schedule: '600px' }}
@@ -89,41 +143,43 @@ const Schedule = ({ isCampaignMode }: { isCampaignMode?: boolean }) => {
       id="calendar"
       className="account-schedule"
     >
-      <FullCalendar
-        ref={scheduleRef}
-        plugins={[dayGridPlugin, interactionPlugin, view]}
-        initialView="custom"
-        headerToolbar={{
-          start: 'prev',
-          center: 'title',
-          end: 'next',
-        }}
-        dayCellContent={(day) => {
-          const hasEvent = events.some((event) =>
-            isSameDay(event.start, day.date),
-          )
+      <StyleWrapper className={excludedDaysClassName}>
+        <FullCalendar
+          ref={scheduleRef}
+          plugins={[dayGridPlugin, interactionPlugin, view]}
+          initialView="custom"
+          headerToolbar={{
+            start: 'prev',
+            center: 'title',
+            end: 'next',
+          }}
+          initialDate={isCampaignMode && currentCampaign?.campaign_start}
+          dayCellContent={(day) => {
+            const hasEvent = events.some((event) =>
+              isSameDay(event.start, day.date),
+            )
 
-          return (
-            <Box
-              color={hasEvent && 'black'}
-              borderBottom={isToday(day.date) && '1px solid orange'}
-              lineHeight="1"
-              fontSize={{ base: '11px', sm: 'sm', md: 'md' }}
-              pt={{ base: 0, sm: 0.5 }}
-            >
-              {day.dayNumberText}
-            </Box>
-          )
-        }}
-        dateClick={() => {
-          if (eventsIdToDelete.length > 0) setToDelete([])
-        }}
-        fixedWeekCount={false}
-        nextDayThreshold="00:00"
-        events={events}
-        locale={frLocale}
-        initialDate={isCampaignMode && currentCampaign?.campaign_start}
-      />
+            return (
+              <Box
+                color={hasEvent && 'black'}
+                borderBottom={isToday(day.date) && '1px solid orange'}
+                lineHeight="1"
+                fontSize={{ base: '11px', sm: 'sm', md: 'md' }}
+                pt={{ base: 0, sm: 0.5 }}
+              >
+                {day.dayNumberText}
+              </Box>
+            )
+          }}
+          dateClick={() => {
+            if (eventsIdToDelete.length > 0) setToDelete([])
+          }}
+          fixedWeekCount={false}
+          nextDayThreshold="00:00"
+          events={events}
+          locale={frLocale}
+        />
+      </StyleWrapper>
     </Flex>
   )
 }

--- a/web/components/Account/Place/ScheduleSlot.tsx
+++ b/web/components/Account/Place/ScheduleSlot.tsx
@@ -52,7 +52,6 @@ const getStyle = (status) => {
 
 const Event = ({
   status = null,
-  when = null,
   range = null,
   id = null,
   isCampaignEvent = false,
@@ -116,7 +115,14 @@ const Event = ({
       {...getStyle(status)}
       opacity={isDisabled ? 0.2 : 1}
     >
-      {isPeriod && <PeriodEvent isMonth start={range.start} end={range.end} />}
+      {isPeriod && (
+        <PeriodEvent
+          isMonth
+          start={range.start}
+          end={range.end}
+          isCampaignEvent={isCampaignEvent}
+        />
+      )}
     </Box>
   )
 }
@@ -157,6 +163,7 @@ interface Props {
   range: { start: Date; end: Date }
   isCampaignEvent?: boolean
   isCampaignMode?: boolean
+  day: Date
 }
 
 const ScheduleSlot = (props: Props) => {

--- a/web/components/Campaign/Places/CampaignDatePicker.tsx
+++ b/web/components/Campaign/Places/CampaignDatePicker.tsx
@@ -1,25 +1,51 @@
 import React, { useEffect, useContext, useMemo } from 'react'
-import { Box, HStack, Input, Text, VStack } from '@chakra-ui/react'
+import { Box, HStack, Input } from '@chakra-ui/react'
 import InputDate from '~components/InputDate'
 import FormField from '~components/FormField'
 import { useTranslation } from 'next-i18next'
-import { ScheduleEventType } from '~@types/schedule-event.d'
-import { useFormContext } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import isSameDay from 'date-fns/isSameDay'
 import addDays from 'date-fns/addDays'
 import subDays from 'date-fns/subDays'
 import ScheduleContext from '~components/Account/Place/ScheduleContext'
 import eachDayOfInterval from 'date-fns/eachDayOfInterval'
 import useCampaignContext from '~components/Campaign/useCampaignContext'
-import { format } from '~utils/date'
 import InputMultiSelect from '~components/InputMultiSelect'
 import { Control } from 'react-hook-form'
+
+const getEndDate = (
+  startDate: Date,
+  offWeekDays: number[],
+  duration: number,
+) => {
+  let exclude_days = []
+  let endDate = new Date(startDate)
+  let addedDays = 0
+
+  while (addedDays < duration - 1) {
+    const nextDate = addDays(endDate, 1)
+
+    if (!offWeekDays.includes(endDate.getDay())) {
+      ++addedDays
+    } else {
+      exclude_days.push(endDate.toString())
+    }
+    endDate = nextDate
+  }
+
+  return { endDate, exclude_days }
+}
 
 const CampaignDatePicker = ({ control }: { control?: Control }) => {
   const { currentCampaign } = useCampaignContext()
   const { t } = useTranslation('place')
-  const { errors, watch, setValue, register, getValues } = useFormContext()
-  const { type, start, when } = watch(['type', 'start', 'end', 'when'])
+  const { errors, watch, setValue, getValues } = useFormContext()
+  const { type, start, when, offWeekDays } = watch([
+    'type',
+    'start',
+    'when',
+    'offWeekDays',
+  ])
 
   const { oldEvents } = useContext(ScheduleContext)
 
@@ -63,10 +89,16 @@ const CampaignDatePicker = ({ control }: { control?: Control }) => {
 
   useEffect(() => {
     if (start) {
-      const startDate = new Date(start)
-      setValue('end', addDays(startDate, currentCampaign?.duration - 1))
+      const { endDate, exclude_days } = getEndDate(
+        new Date(start),
+        offWeekDays,
+        currentCampaign?.duration,
+      )
+
+      setValue('end', endDate)
+      setValue('exclude_days', exclude_days)
     }
-  }, [start])
+  }, [offWeekDays, start])
 
   return (
     <HStack spacing={5} w="100%" alignItems="flex-start">
@@ -87,15 +119,22 @@ const CampaignDatePicker = ({ control }: { control?: Control }) => {
       </Box>
 
       <InputMultiSelect
-        name="exclude_days"
+        name="offWeekDays"
         label={t('campaign.schedule.days_exclude.label')}
         placeholder={t('campaign.schedule.days_exclude.placeholder')}
         options={Array.from({ length: 7 }, (v, i) => ({
-          value: i.toString(),
+          value: i + 1,
           label: t(`campaign.schedule.days_exclude.${i}`),
         }))}
-        isDisabled={true}
       />
+      <Box display="none">
+        <Controller
+          as={<input />}
+          name="exclude_days"
+          control={control}
+          defaultValue={[]}
+        />
+      </Box>
     </HStack>
   )
 }

--- a/web/components/Campaign/Places/CampaignSchedule.tsx
+++ b/web/components/Campaign/Places/CampaignSchedule.tsx
@@ -20,6 +20,8 @@ interface Props {
 interface CampaignScheduleFormValues {
   type: string
   isCampaignEvent: boolean
+  exclude_days: string[]
+  offWeekDays: number[]
 }
 
 const CampaignPlaceSchedule = ({ place }: Props) => {
@@ -43,6 +45,7 @@ const CampaignPlaceSchedule = ({ place }: Props) => {
       .typeError(t('mixed.required'))
       .required(t('mixed.required')),
     exclude_days: yup.array(),
+    offWeekDays: yup.array(),
   })
   const form = useForm<CampaignScheduleFormValues>({
     resolver: yupResolver(campaignScheduleSchema),
@@ -50,6 +53,7 @@ const CampaignPlaceSchedule = ({ place }: Props) => {
     defaultValues: {
       type: ScheduleEventType.PERIOD,
       isCampaignEvent: true,
+      offWeekDays: [],
     },
   })
   const { eventsIdToDelete } = useContext(ScheduleContext)
@@ -65,9 +69,9 @@ const CampaignPlaceSchedule = ({ place }: Props) => {
     <FormProvider {...form}>
       <ScheduleProvider place={place}>
         <Stack direction={{ base: 'column-reverse', lg: 'row' }} spacing={4}>
-          <Box flex={1}>
+          <Stack flex={1} alignItems="stretch">
             <Schedule isCampaignMode />
-          </Box>
+          </Stack>
 
           <Box flex={1}>
             {showForm ? (

--- a/web/components/Campaign/Places/CampaignScheduleForm.tsx
+++ b/web/components/Campaign/Places/CampaignScheduleForm.tsx
@@ -62,6 +62,7 @@ const CampaignScheduleForm = ({ place, hideForm }: Props) => {
     staff,
     accomodation,
     scene_grid,
+    exclude_days,
   }) => {
     setLoading(true)
 
@@ -80,10 +81,10 @@ const CampaignScheduleForm = ({ place, hideForm }: Props) => {
           accomodation,
           scene_grid,
           status: 'available',
+          exclude_days,
         },
       ])
       .then((res) => {
-        console.log(res.data, 'RES DATA')
         queryClient.setQueryData(['place', place.slug], {
           ...place,
           disponibilities: [

--- a/web/components/InputMultiSelect.tsx
+++ b/web/components/InputMultiSelect.tsx
@@ -13,7 +13,7 @@ const InputMultiSelect = ({
   label: string
   name: string
   placeholder: string
-  options: { label: string; value: string }[]
+  options: { label: string; value: string | number }[]
   isDisabled?: boolean
 }) => {
   const { errors, control } = useFormContext()

--- a/web/components/Place/PeriodEvent.tsx
+++ b/web/components/Place/PeriodEvent.tsx
@@ -9,6 +9,7 @@ interface Props {
   isMonth: boolean
   start: Date
   end: Date
+  isCampaignEvent?: boolean
 }
 
 const stylePeriodMonth = {
@@ -23,7 +24,7 @@ const styleLastDay = {
   right: 'auto',
 }
 
-const PeriodEvent = ({ isMonth, start, end }: Props) => {
+const PeriodEvent = ({ isMonth, start, end, isCampaignEvent }: Props) => {
   const { t } = useTranslation('place')
   const nbDays = useMemo(() => differenceInDays(end, start) + 1, [start, end])
   const isLastDay = useMemo(() => isSunday(start), [start])
@@ -50,9 +51,13 @@ const PeriodEvent = ({ isMonth, start, end }: Props) => {
       <Box color={status === 'selected' ? 'blue.500' : 'black'}>
         {`${formattedStart} - ${formattedEnd}`}
       </Box>
-      <Box color="grayText.1">
-        {t(`schedule.${isLastDay ? 'nbDays' : 'nbDays()'}`, { nb: nbDays })}
-      </Box>
+      {!isCampaignEvent && (
+        <Box color="grayText.1">
+          {t(`schedule.${isLastDay ? 'nbDays' : 'nbDays()'}`, {
+            nb: nbDays,
+          })}
+        </Box>
+      )}
     </Stack>
   )
 }

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -18,6 +18,7 @@ import 'swiper/swiper-bundle.min.css'
 import '@fullcalendar/common/main.css'
 import '@fullcalendar/daygrid/main.css'
 import CampaignProvider from '~components/Campaign/CampaignProvider'
+// import './schedule.css'
 
 let ErrorBoundary: BugsnagErrorBoundary
 

--- a/web/public/assets/icons/EyeIcon.tsx
+++ b/web/public/assets/icons/EyeIcon.tsx
@@ -9,14 +9,14 @@ const EyeIcon = ({ stroke }) => (
     <path
       d="M0.5 8C0.5 8 3.5 2.5 8 2.5C12.5 2.5 15.5 8 15.5 8C15.5 8 12.5 13.5 8 13.5C3.5 13.5 0.5 8 0.5 8Z"
       stroke={stroke}
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M8 10.5C9.38071 10.5 10.5 9.38071 10.5 8C10.5 6.61929 9.38071 5.5 8 5.5C6.61929 5.5 5.5 6.61929 5.5 8C5.5 9.38071 6.61929 10.5 8 10.5Z"
       stroke={stroke}
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      stroke-strokeLinejoin="round"
     />
   </svg>
 )

--- a/web/typings/api.ts
+++ b/web/typings/api.ts
@@ -109,6 +109,7 @@ export interface Application {
     staff?: object;
     accomodation?: number;
     scene_grid?: boolean;
+    exclude_days?: object;
     published_at?: string;
     created_by?: string;
     updated_by?: string;
@@ -203,6 +204,7 @@ export interface Campaign {
     staff?: object;
     accomodation?: number;
     scene_grid?: boolean;
+    exclude_days?: object;
     published_at?: string;
     created_by?: string;
     updated_by?: string;
@@ -256,6 +258,7 @@ export interface Campaign {
     created_by?: string;
     updated_by?: string;
   }[];
+  applications_max?: number;
 
   /** @format date-time */
   published_at?: string;
@@ -293,6 +296,7 @@ export interface NewCampaign {
   /** @format date */
   campaign_end?: string;
   users_permissions_users?: string[];
+  applications_max?: number;
 
   /** @format date-time */
   published_at?: string;
@@ -485,6 +489,7 @@ export interface Disponibility {
     campaign_start?: string;
     campaign_end?: string;
     users_permissions_users?: string[];
+    applications_max?: number;
     published_at?: string;
     created_by?: string;
     updated_by?: string;
@@ -500,6 +505,7 @@ export interface Disponibility {
   staff?: object;
   accomodation?: number;
   scene_grid?: boolean;
+  exclude_days?: object;
 
   /** @format date-time */
   published_at?: string;
@@ -524,6 +530,7 @@ export interface NewDisponibility {
   staff?: object;
   accomodation?: number;
   scene_grid?: boolean;
+  exclude_days?: object;
 
   /** @format date-time */
   published_at?: string;
@@ -550,6 +557,7 @@ export interface Dispositif {
     staff?: object;
     accomodation?: number;
     scene_grid?: boolean;
+    exclude_days?: object;
     published_at?: string;
     created_by?: string;
     updated_by?: string;

--- a/web/utils/schedule.ts
+++ b/web/utils/schedule.ts
@@ -22,6 +22,7 @@ export const createScheduleEventObj = ({
   id = null,
   hasEventSameDay = false,
   isCampaignEvent = false,
+  ...props
 }): ScheduleEvent => {
   return {
     start: new Date(start),
@@ -33,6 +34,7 @@ export const createScheduleEventObj = ({
       type,
       hasEventSameDay,
       isCampaignEvent,
+      ...props,
     },
   }
 }
@@ -106,6 +108,7 @@ export const createOldEvents = (
         type: dispo.type,
         hasEventSameDay: checkIfEventSameDay(dispo, array),
         isCampaignEvent: Boolean(dispo?.campaign),
+        exclude_days: dispo?.exclude_days as string[],
       })
     })
 }
@@ -147,7 +150,6 @@ export const createNewEvents = (form, oldEventsDate = [], isError = false) => {
             start,
             when: form.when,
             type: form.type,
-            isCampaignEvent: form.isCampaignEvent,
           }),
         ),
       )
@@ -157,7 +159,6 @@ export const createNewEvents = (form, oldEventsDate = [], isError = false) => {
           start: transformedStart,
           when: form.when,
           type: form.type,
-          isCampaignEvent: form.isCampaignEvent,
         }),
       )
     }
@@ -182,6 +183,7 @@ export const createNewEvents = (form, oldEventsDate = [], isError = false) => {
           start,
           end,
           isCampaignEvent: form.isCampaignEvent,
+          exclude_days: form.exclude_days,
         }),
       )
     }


### PR DESCRIPTION
**Issue**
https://github.com/premieroctet/studio-d-suivi/issues/24

**Description**
@shinework help : je ne trouve pas le moyen d'afficher les jours exclus de la sélection

La maquette indique qu'il faudrait griser les jours exclus :
<img width="721" alt="image" src="https://github.com/AtelierdeParis/studio-d/assets/25606391/ed2126b8-1689-44b7-bac6-8a4a3411e3e5">
Mais FullCalendar n'a pas l'air d'être aussi flexible. Je pensais récupérer calculer la liste des dates exclues et la sauvegarder dans le formulaire puis créer autant d'évènement jours que de dates exclues mais je ne trouve pas le moyen d'afficher un évènement au sein d'un autre (problème de style calculé dans un élément parent du conteneur du jour concerné). 
<img width="568" alt="image" src="https://github.com/AtelierdeParis/studio-d/assets/25606391/a1206318-ce62-4520-872a-c59d787247b9">

Est-ce que tu vois une solution plus efficace ? Je tourne en rond là.

