### PR TITLE
Show switch only to both campaign and solidarity places detail page

### DIFF
--- a/web/components/Campaign/Places/Detail/CampaignPlaceDetail.tsx
+++ b/web/components/Campaign/Places/Detail/CampaignPlaceDetail.tsx
@@ -40,9 +40,11 @@ const CampaignPlaceDetail = ({ place }: Props) => {
     )
   }, [place])
 
-  const { campaignDispos, solidarityDisposNum } = useCampaignDispo(
-    place?.disponibilities,
-  )
+  const {
+    campaignDispos,
+    solidarityDisposNum,
+    campaignDisposNum,
+  } = useCampaignDispo(place?.disponibilities)
 
   return (
     <Box>
@@ -81,7 +83,9 @@ const CampaignPlaceDetail = ({ place }: Props) => {
           <PlaceDetailCalendar place={place} />
         )}
 
-        <CampaignDetailSwitcher isCampaignTab={isCampaignTab} />
+        {Boolean(solidarityDisposNum && campaignDispos) && (
+          <CampaignDetailSwitcher isCampaignTab={isCampaignTab} />
+        )}
 
         {isMobile && (
           <PlaceAttributesGridMobile


### PR DESCRIPTION
- Ne montrer le switch entre les tabs sur la page de détail d'un lieu en mode campagne QUE si le lieu dispose de créneaux solidaires ET de créneaux campagne