### PR TITLE
Navigation administration

### DIFF
--- a/back/api/page/documentation/1.0.0/page.json
+++ b/back/api/page/documentation/1.0.0/page.json
@@ -534,6 +534,15 @@
           "url": {
             "type": "string",
             "minLength": 1
+          },
+          "link_title": {
+            "type": "string"
+          },
+          "show_in_header": {
+            "type": "boolean"
+          },
+          "show_in_footer": {
+            "type": "boolean"
           }
         }
       },
@@ -551,6 +560,15 @@
           "url": {
             "type": "string",
             "minLength": 1
+          },
+          "link_title": {
+            "type": "string"
+          },
+          "show_in_header": {
+            "type": "boolean"
+          },
+          "show_in_footer": {
+            "type": "boolean"
           },
           "created_by": {
             "type": "string"

--- a/back/api/page/models/page.settings.json
+++ b/back/api/page/models/page.settings.json
@@ -22,6 +22,15 @@
       "required": true,
       "unique": true,
       "minLength": 1
+    },
+    "link_title": {
+      "type": "string"
+    },
+    "show_in_header": {
+      "type": "boolean"
+    },
+    "show_in_footer": {
+      "type": "boolean"
     }
   }
 }

--- a/back/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/back/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "03/07/2024 4:37:03 PM"
+    "x-generation-date": "03/07/2024 6:11:31 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -14504,6 +14504,15 @@
           "url": {
             "type": "string",
             "minLength": 1
+          },
+          "link_title": {
+            "type": "string"
+          },
+          "show_in_header": {
+            "type": "boolean"
+          },
+          "show_in_footer": {
+            "type": "boolean"
           }
         }
       },
@@ -14521,6 +14530,15 @@
           "url": {
             "type": "string",
             "minLength": 1
+          },
+          "link_title": {
+            "type": "string"
+          },
+          "show_in_header": {
+            "type": "boolean"
+          },
+          "show_in_footer": {
+            "type": "boolean"
           },
           "created_by": {
             "type": "string"

--- a/web/components/FooterMenu.tsx
+++ b/web/components/FooterMenu.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'next-i18next'
 import SigninModal from '~components/Signin/SigninModal'
 import { useSession } from 'next-auth/client'
 import useCampaignContext from '~components/Campaign/useCampaignContext'
+import { usePages } from '~hooks/usePages'
 
 const MenuItem = ({ href, text }) => {
   return (
@@ -28,18 +29,19 @@ const FooterMenu = () => {
   const [session, loading] = useSession()
   const { t } = useTranslation()
   const { currentCampaign } = useCampaignContext()
+  const { data: pages } = usePages({ show_in_footer: true })
+
   return (
     <Box>
       <Flex pr={12}>
         <Box>
           <MenuItem href="/" text={t('nav.home')} />
           <MenuItem href={ROUTE_PROJECT} text={t('nav.project')} />
-          {currentCampaign?.article_link && (
-            <MenuItem
-              href={currentCampaign?.article_link}
-              text={t('nav.campaign', { title: currentCampaign?.title })}
-            />
-          )}
+
+          {pages?.map((page) => (
+            <MenuItem key={page.id} href={page.url} text={page.link_title} />
+          ))}
+
           <MenuItem href={ROUTE_PLACES} text={t('nav.places')} />
           <MenuItem href={ROUTE_ACTU} text={t('nav.news')} />
           <MenuItem href={ROUTE_FAQ} text={t('nav.faq')} />

--- a/web/components/MobileMenu.tsx
+++ b/web/components/MobileMenu.tsx
@@ -31,6 +31,7 @@ import { useCurrentUser } from '~hooks/useCurrentUser'
 import Squares from 'public/assets/img/squares.svg'
 import AuthenticatedMenu from '~components/AuthenticatedMenu'
 import useCampaignContext from '~components/Campaign/useCampaignContext'
+import { usePages } from '~hooks/usePages'
 
 const MenuItem = ({ href, text }) => {
   const router = useRouter()
@@ -66,6 +67,7 @@ const MobileMenu = ({ colorMode }: Props) => {
   const { data: user } = useCurrentUser()
   const router = useRouter()
   const { currentCampaign } = useCampaignContext()
+  const { data: pages } = usePages({ show_in_header: true })
 
   useEffect(() => {
     if (isOpen) {
@@ -124,12 +126,15 @@ const MobileMenu = ({ colorMode }: Props) => {
               )}
 
               <MenuItem href={ROUTE_PROJECT} text={t('nav.project')} />
-              {currentCampaign && currentCampaign?.article_link && (
+
+              {pages?.map((page) => (
                 <MenuItem
-                  href={currentCampaign?.article_link}
-                  text={t('nav.campaign', { title: currentCampaign?.title })}
+                  key={page.id}
+                  href={page.url}
+                  text={page.link_title}
                 />
-              )}
+              ))}
+
               <MenuItem href={ROUTE_ACTU} text={t('nav.news')} />
               <MenuItem href={ROUTE_FAQ} text={t('nav.faq')} />
               <MenuItem href={ROUTE_CONTACT} text={t('nav.contact')} />

--- a/web/components/Navigation/Header.tsx
+++ b/web/components/Navigation/Header.tsx
@@ -26,6 +26,7 @@ import {
   DropdownNavButton,
   NavButton,
 } from '~components/Navigation/NavigationButtons'
+import { usePages } from '~hooks/usePages'
 
 interface Props {
   colorMode: 'white' | 'black'
@@ -34,6 +35,7 @@ interface Props {
 const Header = ({ colorMode }: Props) => {
   const { t } = useTranslation('common')
   const { currentCampaign } = useCampaignContext()
+  const { data: pages } = usePages({ show_in_header: true })
 
   return (
     <Container
@@ -110,12 +112,11 @@ const Header = ({ colorMode }: Props) => {
             }}
           />
           <NavButton href={ROUTE_PROJECT} text={t('nav.project')} />
-          {currentCampaign && currentCampaign?.article_link && (
-            <NavButton
-              href={currentCampaign?.article_link}
-              text={t('nav.campaign', { title: currentCampaign?.title })}
-            />
-          )}
+
+          {pages?.map((page) => (
+            <NavButton key={page.id} href={page.url} text={page.link_title} />
+          ))}
+
           <NavButton href={ROUTE_ACTU} text={t('nav.news')} />
           <NavButton href={ROUTE_FAQ} text={t('nav.faq')} />
           <NavButton href={ROUTE_CONTACT} text={t('nav.contact')} />

--- a/web/hooks/usePages.ts
+++ b/web/hooks/usePages.ts
@@ -1,0 +1,8 @@
+import { useQuery } from 'react-query'
+import { client } from '~api/client-api'
+
+export const usePages = (query: Record<string, any> = {}, name = 'places') => {
+  return useQuery([name, query], () =>
+    client.pages.pagesList(query).then((res) => res.data),
+  )
+}

--- a/web/typings/api.ts
+++ b/web/typings/api.ts
@@ -1056,12 +1056,18 @@ export interface Page {
   title?: string;
   text?: string;
   url: string;
+  link_title?: string;
+  show_in_header?: boolean;
+  show_in_footer?: boolean;
 }
 
 export interface NewPage {
   title?: string;
   text?: string;
   url: string;
+  link_title?: string;
+  show_in_header?: boolean;
+  show_in_footer?: boolean;
   created_by?: string;
   updated_by?: string;
 }


### PR DESCRIPTION
https://github.com/premieroctet/studio-d-suivi/issues/40
@ImaCrea  une solution pour un affichage simplifié des liens dans le header et le footer mais pas sûre que la feature soit suffisamment creusée pour des cas d'usage plus spécifiques. Exemple : 
- pas possibilité d'imposer un ordre dans les liens 
- pas de choix du positionnement des liens dans le footer
- pas de limite au nombre de lien que l'on peut ajouter

Si cette solution simplifiée convient je merge, sinon il faudra prendre le temps de construire une feature plus aboutie pour une bonne gestion d'une navigation dynamique.