### PR TITLE
Fix typo

### DIFF
--- a/web/public/locales/fr/application.json
+++ b/web/public/locales/fr/application.json
@@ -56,8 +56,8 @@
     "helper": {
       "preselection_start": "Établissez votre présélection avant le {{date}}.",
       "no_preselection": {
-        "singular": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir 1 candidature",
-        "plural": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir {{preselections_max}} candidatures"
+        "singular": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir 1 candidature.",
+        "plural": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir {{preselections_max}} candidatures."
       },
       "missing_preselections": "Il est recommandé d'ajouter {{num}} candidatures supplémentaires.",
       "missing_preselection": "Il est recommandé d'ajouter {{num}} candidature supplémentaire.",

--- a/web/public/locales/fr/application.json
+++ b/web/public/locales/fr/application.json
@@ -57,7 +57,7 @@
       "preselection_start": "Établissez votre présélection avant le {{date}}.",
       "no_preselection": {
         "singular": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir 1 candidature",
-        "plural": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir {{applications_max}} candidatures"
+        "plural": "Établissez votre présélection avant le {{preselection_end_date}}. Il est recommandé de choisir {{preselections_max}} candidatures"
       },
       "missing_preselections": "Il est recommandé d'ajouter {{num}} candidatures supplémentaires.",
       "missing_preselection": "Il est recommandé d'ajouter {{num}} candidature supplémentaire.",


### PR DESCRIPTION
Erreur de variable sur bulle d'info :

![Capture d’écran 2025-01-21 à 13 37 02](https://github.com/user-attachments/assets/5fc2e16d-817f-4f2b-bab6-0bf91b8cb1a6)

C'est `preselections_max` qui devrait s'afficher et pas `applications_max`